### PR TITLE
feature: 詳細画面表示(アイコン表示以外)

### DIFF
--- a/lib/datastore/weather_fetch_datastore.dart
+++ b/lib/datastore/weather_fetch_datastore.dart
@@ -8,7 +8,7 @@ class WeatherFetchDataStore implements WeatherFetchDataStoreInterface {
   final Dio dio;
   WeatherFetchDataStore({required this.dio});
 
-  final String _baseUrl = "api.openweathermap.org/data/2.5/forecast?r";
+  final String _baseUrl = "https://api.openweathermap.org/data/2.5/forecast";
   final String _apikey = Env.key;
 
   @override

--- a/lib/extension/date_time_extension.dart
+++ b/lib/extension/date_time_extension.dart
@@ -1,0 +1,15 @@
+import 'package:intl/intl.dart';
+
+extension DateTimeExtension on DateTime {
+  String get dateAsStringYMD {
+    return DateFormat('y年M月d日').format(this);
+  }
+
+  String get dateAsStringMMDD {
+    return DateFormat('MM月dd日').format(this);
+  }
+
+  String get dateAsStringHHMM {
+    return DateFormat('HH:mm').format(this);
+  }
+}

--- a/lib/extension/date_time_extension.dart
+++ b/lib/extension/date_time_extension.dart
@@ -1,15 +1,15 @@
 import 'package:intl/intl.dart';
 
 extension DateTimeExtension on DateTime {
-  String get dateAsStringYMD {
+  String get asStringYMD {
     return DateFormat('y年M月d日').format(this);
   }
 
-  String get dateAsStringMMDD {
+  String get asStringMMDD {
     return DateFormat('MM月dd日').format(this);
   }
 
-  String get dateAsStringHHMM {
+  String get asStringHHMM {
     return DateFormat('HH:mm').format(this);
   }
 }

--- a/lib/extension/int_extension.dart
+++ b/lib/extension/int_extension.dart
@@ -1,0 +1,13 @@
+import 'package:weather_app_flutter_mvvm/extension/date_time_extension.dart';
+
+extension TimeStampExtension on int {
+  String toStringHHMMFromEpoch() {
+    DateTime date = DateTime.fromMillisecondsSinceEpoch(this * 1000);
+    return date.dateAsStringHHMM;
+  }
+
+  String toStringMMDDFromEpoch() {
+    DateTime date = DateTime.fromMillisecondsSinceEpoch(this * 1000);
+    return date.dateAsStringMMDD;
+  }
+}

--- a/lib/extension/int_extension.dart
+++ b/lib/extension/int_extension.dart
@@ -3,11 +3,11 @@ import 'package:weather_app_flutter_mvvm/extension/date_time_extension.dart';
 extension TimeStampExtension on int {
   String toStringHHMMFromEpoch() {
     DateTime date = DateTime.fromMillisecondsSinceEpoch(this * 1000);
-    return date.dateAsStringHHMM;
+    return date.asStringHHMM;
   }
 
   String toStringMMDDFromEpoch() {
     DateTime date = DateTime.fromMillisecondsSinceEpoch(this * 1000);
-    return date.dateAsStringMMDD;
+    return date.asStringMMDD;
   }
 }

--- a/lib/extension/weather_response_extension.dart
+++ b/lib/extension/weather_response_extension.dart
@@ -5,7 +5,7 @@ import 'package:weather_app_flutter_mvvm/model/response/weathre_response_model.d
 extension WeatherResponseModelExtension on WeatherResponseModel {
   List<Map<String, int>> get timeAndPopList {
     return list.map((data) {
-      String time =
+      final String time =
           DateTime.fromMillisecondsSinceEpoch(data.dt * 1000).asStringHHMM;
       int popPercent = (data.pop.isNaN || data.pop.isInfinite)
           ? 0
@@ -17,7 +17,7 @@ extension WeatherResponseModelExtension on WeatherResponseModel {
   Map<String, List<WeatherData>> groupByDate() {
     Map<String, List<WeatherData>> grouped = {};
     for (var data in list) {
-      String formattedDate = data.dt.toStringMMDDFromEpoch();
+      final String formattedDate = data.dt.toStringMMDDFromEpoch();
       if (!grouped.containsKey(formattedDate)) {
         grouped[formattedDate] = [];
       }

--- a/lib/extension/weather_response_extension.dart
+++ b/lib/extension/weather_response_extension.dart
@@ -1,0 +1,28 @@
+import 'package:weather_app_flutter_mvvm/extension/date_time_extension.dart';
+import 'package:weather_app_flutter_mvvm/extension/int_extension.dart';
+import 'package:weather_app_flutter_mvvm/model/response/weathre_response_model.dart';
+
+extension WeatherResponseModelExtension on WeatherResponseModel {
+  List<Map<String, int>> get timeAndPopList {
+    return list.map((data) {
+      String time =
+          DateTime.fromMillisecondsSinceEpoch(data.dt * 1000).dateAsStringHHMM;
+      int popPercent = (data.pop.isNaN || data.pop.isInfinite)
+          ? 0
+          : (data.pop * 100).toInt();
+      return {time: popPercent};
+    }).toList();
+  }
+
+  Map<String, List<WeatherData>> groupByDate() {
+    Map<String, List<WeatherData>> grouped = {};
+    for (var data in list) {
+      String formattedDate = data.dt.toStringMMDDFromEpoch();
+      if (!grouped.containsKey(formattedDate)) {
+        grouped[formattedDate] = [];
+      }
+      grouped[formattedDate]?.add(data);
+    }
+    return grouped;
+  }
+}

--- a/lib/extension/weather_response_extension.dart
+++ b/lib/extension/weather_response_extension.dart
@@ -6,7 +6,7 @@ extension WeatherResponseModelExtension on WeatherResponseModel {
   List<Map<String, int>> get timeAndPopList {
     return list.map((data) {
       String time =
-          DateTime.fromMillisecondsSinceEpoch(data.dt * 1000).dateAsStringHHMM;
+          DateTime.fromMillisecondsSinceEpoch(data.dt * 1000).asStringHHMM;
       int popPercent = (data.pop.isNaN || data.pop.isInfinite)
           ? 0
           : (data.pop * 100).toInt();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weather_app_flutter_mvvm/ui/home/view/home_page.dart';
 
 void main() {
-  runApp(const MainApp());
+  runApp(const ProviderScope(child: MainApp()));
 }
 
 class MainApp extends StatelessWidget {

--- a/lib/ui/detail/component/pop_chart.dart
+++ b/lib/ui/detail/component/pop_chart.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 
-class PopChart extends StatefulWidget {
+class PopChart extends StatelessWidget {
   const PopChart({
     super.key,
     required this.timePopData,
@@ -10,35 +10,10 @@ class PopChart extends StatefulWidget {
   final List<Map<String, int>> timePopData;
 
   @override
-  State<PopChart> createState() => _PopChartState();
-}
-
-class _PopChartState extends State<PopChart> {
-  List<FlSpot> spots = [];
-
-  @override
-  void initState() {
-    super.initState();
-    _setupSpots();
-  }
-
-  void _setupSpots() {
-    for (var i = 0; i < widget.timePopData.length; i++) {
-      double x = i.toDouble();
-      double y = widget.timePopData[i].values.first.toDouble();
-      spots.add(FlSpot(x, y));
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
     return LineChart(
       LineChartData(
-        lineBarsData: [
-          LineChartBarData(
-            spots: spots,
-          )
-        ],
+        lineBarsData: [LineChartBarData(spots: _setupSpots())],
         titlesData: FlTitlesData(
           bottomTitles: AxisTitles(
             sideTitles: SideTitles(
@@ -46,9 +21,9 @@ class _PopChartState extends State<PopChart> {
               interval: 1,
               getTitlesWidget: (double value, TitleMeta meta) {
                 final index = value.toInt();
-                if (index >= 0 && index < widget.timePopData.length) {
+                if (index >= 0 && index < timePopData.length) {
                   return Text(
-                    widget.timePopData[index].keys.first,
+                    timePopData[index].keys.first,
                     style: const TextStyle(
                       fontSize: 10,
                     ),
@@ -87,5 +62,15 @@ class _PopChartState extends State<PopChart> {
         minY: 0,
       ),
     );
+  }
+
+  List<FlSpot> _setupSpots() {
+    List<FlSpot> spots = [];
+    for (var i = 0; i < timePopData.length; i++) {
+      double x = i.toDouble();
+      double y = timePopData[i].values.first.toDouble();
+      spots.add(FlSpot(x, y));
+    }
+    return spots;
   }
 }

--- a/lib/ui/detail/component/pop_chart.dart
+++ b/lib/ui/detail/component/pop_chart.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+class PopChart extends StatefulWidget {
+  const PopChart({
+    super.key,
+    required this.timePopData,
+  });
+
+  final List<Map<String, int>> timePopData;
+
+  @override
+  State<PopChart> createState() => _PopChartState();
+}
+
+class _PopChartState extends State<PopChart> {
+  List<FlSpot> spots = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _setupSpots();
+  }
+
+  void _setupSpots() {
+    for (var i = 0; i < widget.timePopData.length; i++) {
+      double x = i.toDouble();
+      double y = widget.timePopData[i].values.first.toDouble();
+      spots.add(FlSpot(x, y));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LineChart(
+      LineChartData(
+        lineBarsData: [
+          LineChartBarData(
+            spots: spots,
+          )
+        ],
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              interval: 1,
+              getTitlesWidget: (double value, TitleMeta meta) {
+                final index = value.toInt();
+                if (index >= 0 && index < widget.timePopData.length) {
+                  return Text(
+                    widget.timePopData[index].keys.first,
+                    style: const TextStyle(
+                      fontSize: 10,
+                    ),
+                  );
+                }
+                return Container();
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              getTitlesWidget: (value, meta) => Text(
+                '${value.toInt()}',
+                style: const TextStyle(
+                  fontSize: 10,
+                ),
+              ),
+            ),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: false,
+            ),
+          ),
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: false,
+            ),
+          ),
+        ),
+        borderData: FlBorderData(
+          show: true,
+        ),
+        maxY: 100,
+        minY: 0,
+      ),
+    );
+  }
+}

--- a/lib/ui/detail/component/weather_list.dart
+++ b/lib/ui/detail/component/weather_list.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:sticky_headers/sticky_headers/widget.dart';
+import 'package:weather_app_flutter_mvvm/extension/int_extension.dart';
+import 'package:weather_app_flutter_mvvm/model/response/weathre_response_model.dart';
+import 'package:weather_app_flutter_mvvm/ui/detail/component/weather_list_cell.dart';
+
+class WeatherList extends StatelessWidget {
+  const WeatherList({required this.weathreData, super.key});
+
+  final Map<String, List<WeatherData>> weathreData;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: weathreData.length,
+      itemBuilder: (context, index) {
+        String date = weathreData.keys.elementAt(index);
+        List<WeatherData>? threeHourWethers = weathreData[date];
+        if (threeHourWethers == null) {
+          return const Text('データがありません');
+        }
+        return StickyHeader(
+          header: Container(
+            height: 30.0,
+            color: const Color.fromARGB(249, 244, 244, 244),
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            alignment: Alignment.centerLeft,
+            child: Text(
+              date,
+            ),
+          ),
+          content: Column(
+            children: threeHourWethers
+                .map(
+                  (event) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    child: WeatherListCell(
+                      maxTemperature: event.main.tempMax.toStringAsFixed(1),
+                      minTemperature: event.main.tempMin.toStringAsFixed(1),
+                      humidityLevel: event.main.humidity.toString(),
+                      imageName: "01",
+                      time: event.dt.toStringHHMMFromEpoch(),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/detail/component/weather_list_cell.dart
+++ b/lib/ui/detail/component/weather_list_cell.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+
+class WeatherListCell extends StatelessWidget {
+  final String time;
+  final String imageName;
+  final String maxTemperature;
+  final String minTemperature;
+  final String humidityLevel;
+  const WeatherListCell({
+    required this.maxTemperature,
+    required this.minTemperature,
+    required this.humidityLevel,
+    required this.imageName,
+    required this.time,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        children: [
+          Text(time),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Image.asset(
+              'assets/images/splash_logo.png',
+              width: 50,
+              height: 50,
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '最高気温:$maxTemperature ℃',
+                style: const TextStyle(
+                  color: Colors.red,
+                ),
+              ),
+              const SizedBox(
+                height: 5,
+              ),
+              Text(
+                '最低気温:$minTemperature ℃',
+                style: const TextStyle(
+                  color: Colors.blue,
+                ),
+              ),
+              const Gap(5),
+              Text(
+                '湿度:$humidityLevel %',
+                style: const TextStyle(
+                  color: Colors.green,
+                ),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/detail/ui_state/detail_ui_state.dart
+++ b/lib/ui/detail/ui_state/detail_ui_state.dart
@@ -7,7 +7,7 @@ part 'detail_ui_state.freezed.dart';
 @freezed
 class DetailUiState with _$DetailUiState {
   const factory DetailUiState({
-    required String city,
+    required String cityName,
     required List<Map<String, int>> chartData,
     required Map<String, List<WeatherData>> threeHoursWeather,
   }) = _DetailUiState;
@@ -15,7 +15,7 @@ class DetailUiState with _$DetailUiState {
   factory DetailUiState.fromWeatherResponse(
       WeatherResponseModel weatherResponseModel) {
     return DetailUiState(
-      city: weatherResponseModel.city.name,
+      cityName: weatherResponseModel.city.name,
       chartData: weatherResponseModel.timeAndPopList,
       threeHoursWeather: weatherResponseModel.groupByDate(),
     );

--- a/lib/ui/detail/ui_state/detail_ui_state.dart
+++ b/lib/ui/detail/ui_state/detail_ui_state.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:weather_app_flutter_mvvm/extension/weather_response_extension.dart';
+import 'package:weather_app_flutter_mvvm/model/response/weathre_response_model.dart';
+
+part 'detail_ui_state.freezed.dart';
+
+@freezed
+class DetailUiState with _$DetailUiState {
+  const factory DetailUiState({
+    required String city,
+    required List<Map<String, int>> chartData,
+    required Map<String, List<WeatherData>> threeHoursWeather,
+  }) = _DetailUiState;
+
+  factory DetailUiState.fromWeatherResponse(
+      WeatherResponseModel weatherResponseModel) {
+    return DetailUiState(
+      city: weatherResponseModel.city.name,
+      chartData: weatherResponseModel.timeAndPopList,
+      threeHoursWeather: weatherResponseModel.groupByDate(),
+    );
+  }
+}

--- a/lib/ui/detail/ui_state/detail_ui_state.freezed.dart
+++ b/lib/ui/detail/ui_state/detail_ui_state.freezed.dart
@@ -16,7 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$DetailUiState {
-  String get city => throw _privateConstructorUsedError;
+  String get cityName => throw _privateConstructorUsedError;
   List<Map<String, int>> get chartData => throw _privateConstructorUsedError;
   Map<String, List<WeatherData>> get threeHoursWeather =>
       throw _privateConstructorUsedError;
@@ -33,7 +33,7 @@ abstract class $DetailUiStateCopyWith<$Res> {
       _$DetailUiStateCopyWithImpl<$Res, DetailUiState>;
   @useResult
   $Res call(
-      {String city,
+      {String cityName,
       List<Map<String, int>> chartData,
       Map<String, List<WeatherData>> threeHoursWeather});
 }
@@ -51,14 +51,14 @@ class _$DetailUiStateCopyWithImpl<$Res, $Val extends DetailUiState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? city = null,
+    Object? cityName = null,
     Object? chartData = null,
     Object? threeHoursWeather = null,
   }) {
     return _then(_value.copyWith(
-      city: null == city
-          ? _value.city
-          : city // ignore: cast_nullable_to_non_nullable
+      cityName: null == cityName
+          ? _value.cityName
+          : cityName // ignore: cast_nullable_to_non_nullable
               as String,
       chartData: null == chartData
           ? _value.chartData
@@ -81,7 +81,7 @@ abstract class _$$DetailUiStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String city,
+      {String cityName,
       List<Map<String, int>> chartData,
       Map<String, List<WeatherData>> threeHoursWeather});
 }
@@ -97,14 +97,14 @@ class __$$DetailUiStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? city = null,
+    Object? cityName = null,
     Object? chartData = null,
     Object? threeHoursWeather = null,
   }) {
     return _then(_$DetailUiStateImpl(
-      city: null == city
-          ? _value.city
-          : city // ignore: cast_nullable_to_non_nullable
+      cityName: null == cityName
+          ? _value.cityName
+          : cityName // ignore: cast_nullable_to_non_nullable
               as String,
       chartData: null == chartData
           ? _value._chartData
@@ -122,14 +122,14 @@ class __$$DetailUiStateImplCopyWithImpl<$Res>
 
 class _$DetailUiStateImpl implements _DetailUiState {
   const _$DetailUiStateImpl(
-      {required this.city,
+      {required this.cityName,
       required final List<Map<String, int>> chartData,
       required final Map<String, List<WeatherData>> threeHoursWeather})
       : _chartData = chartData,
         _threeHoursWeather = threeHoursWeather;
 
   @override
-  final String city;
+  final String cityName;
   final List<Map<String, int>> _chartData;
   @override
   List<Map<String, int>> get chartData {
@@ -149,7 +149,7 @@ class _$DetailUiStateImpl implements _DetailUiState {
 
   @override
   String toString() {
-    return 'DetailUiState(city: $city, chartData: $chartData, threeHoursWeather: $threeHoursWeather)';
+    return 'DetailUiState(cityName: $cityName, chartData: $chartData, threeHoursWeather: $threeHoursWeather)';
   }
 
   @override
@@ -157,7 +157,8 @@ class _$DetailUiStateImpl implements _DetailUiState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$DetailUiStateImpl &&
-            (identical(other.city, city) || other.city == city) &&
+            (identical(other.cityName, cityName) ||
+                other.cityName == cityName) &&
             const DeepCollectionEquality()
                 .equals(other._chartData, _chartData) &&
             const DeepCollectionEquality()
@@ -167,7 +168,7 @@ class _$DetailUiStateImpl implements _DetailUiState {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      city,
+      cityName,
       const DeepCollectionEquality().hash(_chartData),
       const DeepCollectionEquality().hash(_threeHoursWeather));
 
@@ -180,13 +181,13 @@ class _$DetailUiStateImpl implements _DetailUiState {
 
 abstract class _DetailUiState implements DetailUiState {
   const factory _DetailUiState(
-          {required final String city,
+          {required final String cityName,
           required final List<Map<String, int>> chartData,
           required final Map<String, List<WeatherData>> threeHoursWeather}) =
       _$DetailUiStateImpl;
 
   @override
-  String get city;
+  String get cityName;
   @override
   List<Map<String, int>> get chartData;
   @override

--- a/lib/ui/detail/ui_state/detail_ui_state.freezed.dart
+++ b/lib/ui/detail/ui_state/detail_ui_state.freezed.dart
@@ -1,0 +1,198 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'detail_ui_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$DetailUiState {
+  String get city => throw _privateConstructorUsedError;
+  List<Map<String, int>> get chartData => throw _privateConstructorUsedError;
+  Map<String, List<WeatherData>> get threeHoursWeather =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $DetailUiStateCopyWith<DetailUiState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DetailUiStateCopyWith<$Res> {
+  factory $DetailUiStateCopyWith(
+          DetailUiState value, $Res Function(DetailUiState) then) =
+      _$DetailUiStateCopyWithImpl<$Res, DetailUiState>;
+  @useResult
+  $Res call(
+      {String city,
+      List<Map<String, int>> chartData,
+      Map<String, List<WeatherData>> threeHoursWeather});
+}
+
+/// @nodoc
+class _$DetailUiStateCopyWithImpl<$Res, $Val extends DetailUiState>
+    implements $DetailUiStateCopyWith<$Res> {
+  _$DetailUiStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? city = null,
+    Object? chartData = null,
+    Object? threeHoursWeather = null,
+  }) {
+    return _then(_value.copyWith(
+      city: null == city
+          ? _value.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String,
+      chartData: null == chartData
+          ? _value.chartData
+          : chartData // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, int>>,
+      threeHoursWeather: null == threeHoursWeather
+          ? _value.threeHoursWeather
+          : threeHoursWeather // ignore: cast_nullable_to_non_nullable
+              as Map<String, List<WeatherData>>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$DetailUiStateImplCopyWith<$Res>
+    implements $DetailUiStateCopyWith<$Res> {
+  factory _$$DetailUiStateImplCopyWith(
+          _$DetailUiStateImpl value, $Res Function(_$DetailUiStateImpl) then) =
+      __$$DetailUiStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String city,
+      List<Map<String, int>> chartData,
+      Map<String, List<WeatherData>> threeHoursWeather});
+}
+
+/// @nodoc
+class __$$DetailUiStateImplCopyWithImpl<$Res>
+    extends _$DetailUiStateCopyWithImpl<$Res, _$DetailUiStateImpl>
+    implements _$$DetailUiStateImplCopyWith<$Res> {
+  __$$DetailUiStateImplCopyWithImpl(
+      _$DetailUiStateImpl _value, $Res Function(_$DetailUiStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? city = null,
+    Object? chartData = null,
+    Object? threeHoursWeather = null,
+  }) {
+    return _then(_$DetailUiStateImpl(
+      city: null == city
+          ? _value.city
+          : city // ignore: cast_nullable_to_non_nullable
+              as String,
+      chartData: null == chartData
+          ? _value._chartData
+          : chartData // ignore: cast_nullable_to_non_nullable
+              as List<Map<String, int>>,
+      threeHoursWeather: null == threeHoursWeather
+          ? _value._threeHoursWeather
+          : threeHoursWeather // ignore: cast_nullable_to_non_nullable
+              as Map<String, List<WeatherData>>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$DetailUiStateImpl implements _DetailUiState {
+  const _$DetailUiStateImpl(
+      {required this.city,
+      required final List<Map<String, int>> chartData,
+      required final Map<String, List<WeatherData>> threeHoursWeather})
+      : _chartData = chartData,
+        _threeHoursWeather = threeHoursWeather;
+
+  @override
+  final String city;
+  final List<Map<String, int>> _chartData;
+  @override
+  List<Map<String, int>> get chartData {
+    if (_chartData is EqualUnmodifiableListView) return _chartData;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_chartData);
+  }
+
+  final Map<String, List<WeatherData>> _threeHoursWeather;
+  @override
+  Map<String, List<WeatherData>> get threeHoursWeather {
+    if (_threeHoursWeather is EqualUnmodifiableMapView)
+      return _threeHoursWeather;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_threeHoursWeather);
+  }
+
+  @override
+  String toString() {
+    return 'DetailUiState(city: $city, chartData: $chartData, threeHoursWeather: $threeHoursWeather)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DetailUiStateImpl &&
+            (identical(other.city, city) || other.city == city) &&
+            const DeepCollectionEquality()
+                .equals(other._chartData, _chartData) &&
+            const DeepCollectionEquality()
+                .equals(other._threeHoursWeather, _threeHoursWeather));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      city,
+      const DeepCollectionEquality().hash(_chartData),
+      const DeepCollectionEquality().hash(_threeHoursWeather));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DetailUiStateImplCopyWith<_$DetailUiStateImpl> get copyWith =>
+      __$$DetailUiStateImplCopyWithImpl<_$DetailUiStateImpl>(this, _$identity);
+}
+
+abstract class _DetailUiState implements DetailUiState {
+  const factory _DetailUiState(
+          {required final String city,
+          required final List<Map<String, int>> chartData,
+          required final Map<String, List<WeatherData>> threeHoursWeather}) =
+      _$DetailUiStateImpl;
+
+  @override
+  String get city;
+  @override
+  List<Map<String, int>> get chartData;
+  @override
+  Map<String, List<WeatherData>> get threeHoursWeather;
+  @override
+  @JsonKey(ignore: true)
+  _$$DetailUiStateImplCopyWith<_$DetailUiStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -87,9 +87,9 @@ class _DetailPageState extends ConsumerState<DetailPage> {
                                     const EdgeInsets.symmetric(vertical: 10),
                                 child: _WeatherListCell(
                                   maxTemperature:
-                                      event.main.temp_max.toStringAsFixed(1),
+                                      event.main.tempMax.toStringAsFixed(1),
                                   minTemperature:
-                                      event.main.temp_min.toStringAsFixed(1),
+                                      event.main.tempMin.toStringAsFixed(1),
                                   humidityLevel: event.main.humidity.toString(),
                                   imageName: "01",
                                   time: event.dt.toStringHHMMFromEpoch(),

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -31,9 +31,6 @@ class _DetailPageState extends ConsumerState<DetailPage> {
       appBar: AppBar(),
       body: Center(
         child: uiState.when(data: (data) {
-          if (data == null) {
-            return const CircularProgressIndicator();
-          }
           return Column(
             children: [
               Text(

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -1,32 +1,29 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/component/pop_chart.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/component/weather_list.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/view_model/detail_view_model.dart';
 
-class DetailPage extends ConsumerStatefulWidget {
+class DetailPage extends HookConsumerWidget {
   const DetailPage(this.prefecture, {super.key});
 
   final String prefecture;
 
   @override
-  ConsumerState<DetailPage> createState() => _DetailPageState();
-}
-
-class _DetailPageState extends ConsumerState<DetailPage> {
-  @override
-  void initState() {
-    super.initState();
-    Future.microtask(() {
-      ref
-          .read(detailViewModelProvider.notifier)
-          .fetchWeatherByCity(widget.prefecture);
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final uiState = ref.watch(detailViewModelProvider);
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) {
+          ref
+              .read(detailViewModelProvider.notifier)
+              .fetchWeatherByCity(prefecture);
+        },
+      );
+      return null;
+    }, const []);
+
     return Scaffold(
       appBar: AppBar(),
       body: Center(

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:gap/gap.dart';
-import 'package:sticky_headers/sticky_headers.dart';
-import 'package:weather_app_flutter_mvvm/extension/int_extension.dart';
-import 'package:weather_app_flutter_mvvm/model/response/weathre_response_model.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/component/pop_chart.dart';
+import 'package:weather_app_flutter_mvvm/ui/detail/component/weather_list.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/view_model/detail_view_model.dart';
 
 class DetailPage extends ConsumerStatefulWidget {
@@ -60,47 +57,7 @@ class _DetailPageState extends ConsumerState<DetailPage> {
                 ),
               ),
               Expanded(
-                child: ListView.builder(
-                  itemCount: data.threeHoursWeather.length,
-                  itemBuilder: (context, index) {
-                    String date = data.threeHoursWeather.keys.elementAt(index);
-                    List<WeatherData>? threeHourWethers =
-                        data.threeHoursWeather[date];
-                    if (threeHourWethers == null) {
-                      return const Text('データがありません');
-                    }
-                    return StickyHeader(
-                      header: Container(
-                        height: 30.0,
-                        color: const Color.fromARGB(249, 244, 244, 244),
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          date,
-                        ),
-                      ),
-                      content: Column(
-                        children: threeHourWethers
-                            .map(
-                              (event) => Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 10),
-                                child: _WeatherListCell(
-                                  maxTemperature:
-                                      event.main.tempMax.toStringAsFixed(1),
-                                  minTemperature:
-                                      event.main.tempMin.toStringAsFixed(1),
-                                  humidityLevel: event.main.humidity.toString(),
-                                  imageName: "01",
-                                  time: event.dt.toStringHHMMFromEpoch(),
-                                ),
-                              ),
-                            )
-                            .toList(),
-                      ),
-                    );
-                  },
-                ),
+                child: WeatherList(weathreData: data.threeHoursWeather),
               ),
             ],
           );
@@ -111,68 +68,6 @@ class _DetailPageState extends ConsumerState<DetailPage> {
             child: CircularProgressIndicator(),
           );
         }),
-      ),
-    );
-  }
-}
-
-class _WeatherListCell extends StatelessWidget {
-  final String time;
-  final String imageName;
-  final String maxTemperature;
-  final String minTemperature;
-  final String humidityLevel;
-  const _WeatherListCell({
-    required this.maxTemperature,
-    required this.minTemperature,
-    required this.humidityLevel,
-    required this.imageName,
-    required this.time,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20),
-      child: Row(
-        children: [
-          Text(time),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10),
-            child: Image.asset(
-              'assets/images/splash_logo.png',
-              width: 50,
-              height: 50,
-            ),
-          ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '最高気温:$maxTemperature ℃',
-                style: const TextStyle(
-                  color: Colors.red,
-                ),
-              ),
-              const SizedBox(
-                height: 5,
-              ),
-              Text(
-                '最低気温:$minTemperature ℃',
-                style: const TextStyle(
-                  color: Colors.blue,
-                ),
-              ),
-              const Gap(5),
-              Text(
-                '湿度:$humidityLevel %',
-                style: const TextStyle(
-                  color: Colors.green,
-                ),
-              ),
-            ],
-          )
-        ],
       ),
     );
   }

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -40,7 +40,7 @@ class _DetailPageState extends ConsumerState<DetailPage> {
           return Column(
             children: [
               Text(
-                data.city,
+                data.cityName,
                 style: const TextStyle(
                   fontSize: 20,
                 ),

--- a/lib/ui/detail/view_model/detail_view_model.dart
+++ b/lib/ui/detail/view_model/detail_view_model.dart
@@ -1,0 +1,47 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:weather_app_flutter_mvvm/repository/weather_repository_provider.dart';
+import 'package:weather_app_flutter_mvvm/ui/detail/ui_state/detail_ui_state.dart';
+
+part 'detail_view_model.g.dart';
+
+@riverpod
+class DetailViewModel extends _$DetailViewModel {
+  @override
+  FutureOr<DetailUiState?> build() {
+    return Future<DetailUiState?>.value(null);
+  }
+
+  Future<void> fetchWeatherByCity(
+    String city,
+  ) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () async {
+        final response =
+            await ref.read(weatherRepositoryProvider).fetchWeatherByCity(
+                  city: city,
+                );
+        final uiState = DetailUiState.fromWeatherResponse(response);
+        return uiState;
+      },
+    );
+  }
+
+  Future<void> fetchWeatherByLocation({
+    required double lat,
+    required double lon,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () async {
+        final response =
+            await ref.read(weatherRepositoryProvider).fetchWeatherByLocation(
+                  lat: lat,
+                  lon: lon,
+                );
+        final uiState = DetailUiState.fromWeatherResponse(response);
+        return uiState;
+      },
+    );
+  }
+}

--- a/lib/ui/detail/view_model/detail_view_model.dart
+++ b/lib/ui/detail/view_model/detail_view_model.dart
@@ -7,8 +7,8 @@ part 'detail_view_model.g.dart';
 @riverpod
 class DetailViewModel extends _$DetailViewModel {
   @override
-  Future<DetailUiState?> build() {
-    return Future<DetailUiState?>.value(null);
+  AsyncValue<DetailUiState> build() {
+    return const AsyncLoading<DetailUiState>();
   }
 
   Future<void> fetchWeatherByCity(

--- a/lib/ui/detail/view_model/detail_view_model.dart
+++ b/lib/ui/detail/view_model/detail_view_model.dart
@@ -7,7 +7,7 @@ part 'detail_view_model.g.dart';
 @riverpod
 class DetailViewModel extends _$DetailViewModel {
   @override
-  FutureOr<DetailUiState?> build() {
+  Future<DetailUiState?> build() {
     return Future<DetailUiState?>.value(null);
   }
 

--- a/lib/ui/detail/view_model/detail_view_model.g.dart
+++ b/lib/ui/detail/view_model/detail_view_model.g.dart
@@ -6,12 +6,12 @@ part of 'detail_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$detailViewModelHash() => r'593d196bbf3a18da71b02023d436aecbeb71f8f0';
+String _$detailViewModelHash() => r'0513cc81ce0ca1b8422be867635ae1aa0725db20';
 
 /// See also [DetailViewModel].
 @ProviderFor(DetailViewModel)
-final detailViewModelProvider =
-    AutoDisposeAsyncNotifierProvider<DetailViewModel, DetailUiState?>.internal(
+final detailViewModelProvider = AutoDisposeNotifierProvider<DetailViewModel,
+    AsyncValue<DetailUiState>>.internal(
   DetailViewModel.new,
   name: r'detailViewModelProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -21,6 +21,6 @@ final detailViewModelProvider =
   allTransitiveDependencies: null,
 );
 
-typedef _$DetailViewModel = AutoDisposeAsyncNotifier<DetailUiState?>;
+typedef _$DetailViewModel = AutoDisposeNotifier<AsyncValue<DetailUiState>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/ui/detail/view_model/detail_view_model.g.dart
+++ b/lib/ui/detail/view_model/detail_view_model.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'detail_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$detailViewModelHash() => r'593d196bbf3a18da71b02023d436aecbeb71f8f0';
+
+/// See also [DetailViewModel].
+@ProviderFor(DetailViewModel)
+final detailViewModelProvider =
+    AutoDisposeAsyncNotifierProvider<DetailViewModel, DetailUiState?>.internal(
+  DetailViewModel.new,
+  name: r'detailViewModelProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$detailViewModelHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$DetailViewModel = AutoDisposeAsyncNotifier<DetailUiState?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/ui/home/view/home_page.dart
+++ b/lib/ui/home/view/home_page.dart
@@ -8,7 +8,6 @@ class HomePage extends StatelessWidget {
   });
 
   @override
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/ui/prefecture/view/prefecture_page.dart
+++ b/lib/ui/prefecture/view/prefecture_page.dart
@@ -72,7 +72,7 @@ class PrefecturePage extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const DetailPage(),
+                  builder: (context) => DetailPage(prefectures[index]),
                   fullscreenDialog: true,
                 ),
               );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -273,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: d0f0d49112f2f4b192481c16d05b6418bd7820e021e265a3c22db98acf7ed7fb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.68.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -400,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -783,4 +799,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.1 <4.0.0"
-  flutter: ">=3.7.0"
+  flutter: ">=3.16.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -286,6 +286,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.5"
   flutter_launcher_icons:
     dependency: "direct main"
     description:
@@ -376,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      sha256: "45b2030a18bcd6dbd680c2c91bc3b33e3fe7c323e3acb5ecec93a613e2fbaa8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   dio: ^5.4.3+1
   envied: ^0.5.4+1
+  fl_chart: ^0.68.0
   flutter:
     sdk: flutter
   flutter_launcher_icons: ^0.13.1
@@ -17,6 +18,7 @@ dependencies:
   freezed: ^2.5.2
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
+  intl: ^0.19.0
   json_annotation: ^4.9.0
   riverpod_annotation: ^2.3.5
   riverpod_generator: ^2.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,12 +12,14 @@ dependencies:
   fl_chart: ^0.68.0
   flutter:
     sdk: flutter
+  flutter_hooks: ^0.20.5
   flutter_launcher_icons: ^0.13.1
   flutter_native_splash: ^2.4.0
   flutter_riverpod: ^2.4.1
   freezed: ^2.5.2
   freezed_annotation: ^2.4.1
   gap: ^3.0.1
+  hooks_riverpod: ^2.5.1
   intl: ^0.19.0
   json_annotation: ^4.9.0
   riverpod_annotation: ^2.3.5


### PR DESCRIPTION
## チケットへのリンク 
~~#18 マージ後オープン~~

親課題 #6 天気詳細UI反映
close #11 チャート表示
close #20 リスト表示
チャートとリスト表示でやることがほとんど重なっていたため同時に対応

## やったこと
・DetailViewModelの作成
AsyncNotifierFamilyProviderを使用
・DetailUIStateの作成
都道府県名、チャートデータ、３時間ごとの天気リストをまとめた状態をfreezedで作成

## やらないこと
・エラーハンドリング
・３時間ごとの天気アイコンの表示
#21 天気アイコンの表示で対応予定
1週目はView側でImage.network()を使用してアイコン表示したが、
責務をしっかり分けるため今回は使用しない方法を検討する。

## 動作確認
都道府県選択画面から選択した都道府県の天気情報が表示される。

https://github.com/oggysy/weather_app_flutter_mvvm/assets/93628118/a97e39cc-4a77-4ec9-a945-845a0c4d45fa


## その他
今回はViewModelをAsyncNotifierFamilyProviderで実装しました。
初期で持たせるbuild関数の戻り値でかなり迷いました。。
できれば初期値は AsyncLoadingにしたかったのですが、うまくいかず。
結果的にnullを許容するようにしてbuild関数ではnullを返すようにしました。
そのためViewModelの状態がnullの時View側でインジケータを表示しています。

APIから取得した天気情報を状態として持つため、NotifierProviderを選択しましたが、
今回のアプリのように一度取得して再度更新される可能性がなく、特に状態に対して複雑な処理を行わない場合、普通のFutureProviderでもよかったのかもとも思いました...

また、画面表示時にref.readするために、initState内で
```
Future.microtask(() {
      ref
          .read(detailViewModelProvider.notifier)
          .fetchWeatherByCity(widget.prefecture);
    });
```
という方法を使っています。
ライフサイクル内でref.readするとエラーが発生してしまうため上記対応をしましたが、
こちらはあまり良い方法ではないですかね...

