### PR TITLE
feature: エラーハンドリング

### DIFF
--- a/lib/repository/weather_repository.dart
+++ b/lib/repository/weather_repository.dart
@@ -17,8 +17,8 @@ class WeatherRepository implements WeatherRepositoryInterface {
         city: city,
       );
       return data;
-    } on Exception catch (exception) {
-      throw Exception(exception);
+    } catch (_) {
+      rethrow;
     }
   }
 
@@ -33,8 +33,8 @@ class WeatherRepository implements WeatherRepositoryInterface {
         lon: lon,
       );
       return data;
-    } on Exception catch (exception) {
-      throw Exception(exception);
+    } catch (_) {
+      rethrow;
     }
   }
 

--- a/lib/ui/componet/normal_alert_dialog.dart
+++ b/lib/ui/componet/normal_alert_dialog.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class NormalAlertDialog extends StatelessWidget {
+  const NormalAlertDialog({
+    super.key,
+    required this.title,
+    required this.message,
+  });
+
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/detail/ui_state/detail_error_state.dart
+++ b/lib/ui/detail/ui_state/detail_error_state.dart
@@ -1,3 +1,3 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-final detailErrorStateProvider = StateProvider<String>((ref) => "");
+final detailErrorStateProvider = StateProvider<String?>((ref) => null);

--- a/lib/ui/detail/ui_state/detail_error_state.dart
+++ b/lib/ui/detail/ui_state/detail_error_state.dart
@@ -1,0 +1,3 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final detailErrorStateProvider = StateProvider<String>((ref) => "");

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -15,9 +15,12 @@ class DetailPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final uiState = ref.watch(detailViewModelProvider);
-    ref.listen<String>(
+    ref.listen<String?>(
       detailErrorStateProvider,
       (prev, next) {
+        if (next == null) {
+          return;
+        }
         showDialog(
           context: context,
           builder: ((context) {

--- a/lib/ui/detail/view/detail_page.dart
+++ b/lib/ui/detail/view/detail_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:weather_app_flutter_mvvm/ui/componet/normal_alert_dialog.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/component/pop_chart.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/component/weather_list.dart';
+import 'package:weather_app_flutter_mvvm/ui/detail/ui_state/detail_error_state.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/view_model/detail_view_model.dart';
 
 class DetailPage extends HookConsumerWidget {
@@ -13,6 +15,21 @@ class DetailPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final uiState = ref.watch(detailViewModelProvider);
+    ref.listen<String>(
+      detailErrorStateProvider,
+      (prev, next) {
+        showDialog(
+          context: context,
+          builder: ((context) {
+            return NormalAlertDialog(
+              title: 'エラー',
+              message: next,
+            );
+          }),
+        );
+      },
+    );
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) {
@@ -27,41 +44,45 @@ class DetailPage extends HookConsumerWidget {
     return Scaffold(
       appBar: AppBar(),
       body: Center(
-        child: uiState.when(data: (data) {
-          return Column(
-            children: [
-              Text(
-                data.cityName,
-                style: const TextStyle(
-                  fontSize: 20,
-                ),
-              ),
-              const Text('2024年5月13日'),
-              const Text('降水確率'),
-              SizedBox(
-                width: double.infinity,
-                height: 200.0,
-                child: Padding(
-                  padding: const EdgeInsets.all(
-                    8.0,
-                  ),
-                  child: PopChart(
-                    timePopData: data.chartData,
+        child: uiState.when(
+          data: (data) {
+            return Column(
+              children: [
+                Text(
+                  data.cityName,
+                  style: const TextStyle(
+                    fontSize: 20,
                   ),
                 ),
-              ),
-              Expanded(
-                child: WeatherList(weathreData: data.threeHoursWeather),
-              ),
-            ],
-          );
-        }, error: (e, s) {
-          return Text(e.toString());
-        }, loading: () {
-          return const Center(
-            child: CircularProgressIndicator(),
-          );
-        }),
+                const Text('2024年5月13日'),
+                const Text('降水確率'),
+                SizedBox(
+                  width: double.infinity,
+                  height: 200.0,
+                  child: Padding(
+                    padding: const EdgeInsets.all(
+                      8.0,
+                    ),
+                    child: PopChart(
+                      timePopData: data.chartData,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: WeatherList(weathreData: data.threeHoursWeather),
+                ),
+              ],
+            );
+          },
+          error: (e, s) {
+            return const Text('天気情報を取得できませんでした');
+          },
+          loading: () {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/ui/detail/view_model/detail_view_model.dart
+++ b/lib/ui/detail/view_model/detail_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:weather_app_flutter_mvvm/model/response/weathre_response_model.dart';
 import 'package:weather_app_flutter_mvvm/repository/weather_repository_provider.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/ui_state/detail_error_state.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/ui_state/detail_ui_state.dart';
@@ -14,38 +15,30 @@ class DetailViewModel extends _$DetailViewModel {
     return const AsyncLoading<DetailUiState>();
   }
 
-  Future<void> fetchWeatherByCity(
-    String city,
-  ) async {
-    state = const AsyncLoading();
-    try {
-      final response =
-          await ref.read(weatherRepositoryProvider).fetchWeatherByCity(
-                city: city,
-              );
-      final uiState = DetailUiState.fromWeatherResponse(response);
-      state = AsyncValue.data(uiState);
-    } catch (error, stackTrace) {
-      final errorMessage = error.toString().replaceFirst(
-            'Exception: ',
-            '',
-          );
-      ref.read(detailErrorStateProvider.notifier).state = errorMessage;
-      state = AsyncError(error, stackTrace);
-    }
+  Future<void> fetchWeatherByCity(String city) async {
+    await _fetchWeather(
+      fetch: () =>
+          ref.read(weatherRepositoryProvider).fetchWeatherByCity(city: city),
+    );
   }
 
   Future<void> fetchWeatherByLocation({
     required double lat,
     required double lon,
   }) async {
+    await _fetchWeather(
+      fetch: () => ref
+          .read(weatherRepositoryProvider)
+          .fetchWeatherByLocation(lat: lat, lon: lon),
+    );
+  }
+
+  Future<void> _fetchWeather({
+    required Future<WeatherResponseModel> Function() fetch,
+  }) async {
     state = const AsyncLoading();
     try {
-      final response =
-          await ref.read(weatherRepositoryProvider).fetchWeatherByLocation(
-                lat: lat,
-                lon: lon,
-              );
+      final response = await fetch();
       final uiState = DetailUiState.fromWeatherResponse(response);
       state = AsyncValue.data(uiState);
     } catch (error, stackTrace) {

--- a/lib/ui/detail/view_model/detail_view_model.dart
+++ b/lib/ui/detail/view_model/detail_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:weather_app_flutter_mvvm/repository/weather_repository_provider.dart';
+import 'package:weather_app_flutter_mvvm/ui/detail/ui_state/detail_error_state.dart';
 import 'package:weather_app_flutter_mvvm/ui/detail/ui_state/detail_ui_state.dart';
 
 part 'detail_view_model.g.dart';
@@ -17,16 +18,21 @@ class DetailViewModel extends _$DetailViewModel {
     String city,
   ) async {
     state = const AsyncLoading();
-    state = await AsyncValue.guard(
-      () async {
-        final response =
-            await ref.read(weatherRepositoryProvider).fetchWeatherByCity(
-                  city: city,
-                );
-        final uiState = DetailUiState.fromWeatherResponse(response);
-        return uiState;
-      },
-    );
+    try {
+      final response =
+          await ref.read(weatherRepositoryProvider).fetchWeatherByCity(
+                city: city,
+              );
+      final uiState = DetailUiState.fromWeatherResponse(response);
+      state = AsyncValue.data(uiState);
+    } catch (error, stackTrace) {
+      final errorMessage = error.toString().replaceFirst(
+            'Exception: ',
+            '',
+          );
+      ref.read(detailErrorStateProvider.notifier).state = errorMessage;
+      state = AsyncError(error, stackTrace);
+    }
   }
 
   Future<void> fetchWeatherByLocation({
@@ -34,17 +40,22 @@ class DetailViewModel extends _$DetailViewModel {
     required double lon,
   }) async {
     state = const AsyncLoading();
-    state = await AsyncValue.guard(
-      () async {
-        final response =
-            await ref.read(weatherRepositoryProvider).fetchWeatherByLocation(
-                  lat: lat,
-                  lon: lon,
-                );
-        final uiState = DetailUiState.fromWeatherResponse(response);
-        return uiState;
-      },
-    );
+    try {
+      final response =
+          await ref.read(weatherRepositoryProvider).fetchWeatherByLocation(
+                lat: lat,
+                lon: lon,
+              );
+      final uiState = DetailUiState.fromWeatherResponse(response);
+      state = AsyncValue.data(uiState);
+    } catch (error, stackTrace) {
+      final errorMessage = error.toString().replaceFirst(
+            'Exception: ',
+            '',
+          );
+      ref.read(detailErrorStateProvider.notifier).state = errorMessage;
+      state = AsyncError(error, stackTrace);
+    }
   }
 
   Future<Uint8List> fetchIconImage({

--- a/lib/ui/detail/view_model/detail_view_model.g.dart
+++ b/lib/ui/detail/view_model/detail_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'detail_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$detailViewModelHash() => r'0513cc81ce0ca1b8422be867635ae1aa0725db20';
+String _$detailViewModelHash() => r'0e2b21aabc37a2a51c15b2383926caacc44643ce';
 
 /// See also [DetailViewModel].
 @ProviderFor(DetailViewModel)


### PR DESCRIPTION
## チケットへのリンク
~~#23 マージ後にオープン~~

close #7 エラーハンドリング

## やったこと
・dataStoreにエラーハンドリング追加
ハンドリングする内容については1週目からほとんど変更していません。
・alertコンポーネントの作成
・エラーダイアログの表示
エラーメッセージの状態を管理するdetailErrorStateというStateProviderを作成。
ViewModelと連携させ、エラー時に状態が変わるようにした。
1週目同様Widget内にshowDialogのメソッドを持たせる方がシンプルだったかもしれないのですが、
色々な方法を試すためにもこのようにしてみました。

## やらないこと
・API以外のエラー表示

## 動作確認
エラー時に正常にダイアログが表示される
<img src="https://github.com/oggysy/weather_app_flutter_mvvm/assets/93628118/4364d669-5bed-4a6c-94a6-7239602549e3" width="40%" />

## その他
